### PR TITLE
Fix and improve Application Builder steps

### DIFF
--- a/crates/sword-web/src/request/extract.rs
+++ b/crates/sword-web/src/request/extract.rs
@@ -12,7 +12,6 @@ use axum::{
 };
 use axum_responses::JsonResponse;
 
-#[allow(async_fn_in_trait)]
 /// Fixed-state version of `axum::extract::FromRequest` using sword's State.
 ///
 /// This allows extractors to avoid the generic state parameter while still
@@ -20,19 +19,22 @@ use axum_responses::JsonResponse;
 pub trait FromRequest: Sized {
     type Rejection: IntoResponse;
 
-    async fn from_request(req: AxumReq, state: &State) -> Result<Self, Self::Rejection>;
+    fn from_request(
+        req: AxumReq,
+        state: &State,
+    ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send;
 }
 
-#[allow(async_fn_in_trait)]
 /// Fixed-state version of `axum::extract::FromRequestParts` using sword's State.
 pub trait FromRequestParts: Sized {
     type Rejection: IntoResponse;
 
-    async fn from_request_parts(parts: &mut Parts, state: &State) -> Result<Self, Self::Rejection>;
+    fn from_request_parts(
+        parts: &mut Parts,
+        state: &State,
+    ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send;
 }
 
-/// Implementation of `FromRequest` for `Request`.
-///
 /// Allows `Request` to be automatically extracted from HTTP requests
 /// in Axum handlers, providing easy access to parameters, headers, body, and state.
 impl FromRequest for Request {

--- a/crates/sword/src/application/builder.rs
+++ b/crates/sword/src/application/builder.rs
@@ -187,33 +187,30 @@ impl ApplicationBuilder {
         // NOTE: With --all-features, only the first matching #[cfg] branch is compiled in.
         // The unreachable code and needless return warnings are suppressed here because
         // each branch is reachable under normal single-feature usage.
-        #[allow(unreachable_code)]
-        #[allow(clippy::needless_return)]
-        {
-            #[cfg(feature = "grpc")]
-            {
+        cfg_select! {
+            feature = "grpc" => {
                 let grpc_app = sword_grpc::application::GrpcApplication::from(ctx);
                 let engine = super::ApplicationEngine::Grpc(grpc_app);
 
-                return Application::new(engine, self.config);
+                Application::new(engine, self.config)
             }
 
-            #[cfg(any(feature = "web", feature = "socketio"))]
-            {
+            any(feature = "web", feature = "socketio") => {
                 let web_app = sword_web::application::WebApplication::from(ctx);
                 let engine = super::ApplicationEngine::Web(web_app);
 
-                return Application::new(engine, self.config);
+                Application::new(engine, self.config)
             }
 
-            #[cfg(not(any(feature = "web", feature = "socketio", feature = "grpc")))]
-            sword_error! {
-                title: "No application engine available",
-                reason: "No supported controller feature is enabled",
-                context: {
-                    "source" => "ApplicationBuilder::build",
-                },
-                hints: ["Enable one of: web, socketio, grpc"],
+            _ => {
+                sword_error! {
+                    title: "No application engine available",
+                    reason: "No supported controller feature is enabled",
+                    context: {
+                        "source" => "ApplicationBuilder::build",
+                    },
+                    hints: ["Enable one of: web, socketio, grpc"],
+                }
             }
         }
     }

--- a/crates/sword/src/application/mod.rs
+++ b/crates/sword/src/application/mod.rs
@@ -84,30 +84,30 @@ impl Application {
         match &self.engine {
             #[cfg(any(feature = "web", feature = "socketio"))]
             ApplicationEngine::Web(app) => app.start().await,
+
             #[cfg(feature = "grpc")]
             ApplicationEngine::Grpc(app) => app.start().await,
+
             #[allow(unreachable_patterns)]
-            _ => unreachable!(),
+            _ => unreachable!(
+                "Invalid application engine configuration. Enable the appropriate feature flag to use the desired engine."
+            ),
         }
     }
 
     #[cfg(any(feature = "web", feature = "socketio"))]
     pub fn router(&self) -> axum::Router {
-        match &self.engine {
-            ApplicationEngine::Web(app) => app.router(),
-            #[cfg(feature = "grpc")]
-            ApplicationEngine::Grpc(_) => {
-                sword_error! {
-                    title: "Router API is not available for gRPC engine",
-                    reason: "Application::router() is only valid for web/socketio applications",
-                    context: {
-                        "source" => "Application::router",
-                    },
-                    hints: ["Use Application::run() to start the gRPC server"],
-                }
+        #[cfg(any(feature = "web", feature = "socketio"))]
+        if let ApplicationEngine::Web(app) = &self.engine {
+            return app.router();
+        }
+
+        sword_error! {
+            title: "Router API is only available for web based applications",
+            reason: "Application::router() is only valid for web/socketio applications",
+            context: {
+                "source" => "Application::router",
             }
-            #[allow(unreachable_patterns)]
-            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
Using the new `cfg_select!` macro for conditional feature flag handling on the `ApplicationBuilder`.

```rust
cfg_select! {
    feature = "grpc" => {
        let grpc_app = sword_grpc::application::GrpcApplication::from(ctx);
        let engine = super::ApplicationEngine::Grpc(grpc_app);

        Application::new(engine, self.config)
    }

    any(feature = "web", feature = "socketio") => {
        let web_app = sword_web::application::WebApplication::from(ctx);
        let engine = super::ApplicationEngine::Web(web_app);

        Application::new(engine, self.config)
    }

    _ => {
        sword_error! {
            title: "No application engine available",
            reason: "No supported controller feature is enabled",
            context: {
                "source" => "ApplicationBuilder::build",
            },
            hints: ["Enable one of: web, socketio, grpc"],
        }
    }
}
```

Also minor changes to web request traits. 