### PR TITLE
feat(web): add sse support for web controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `#[sse]` route attribute for Server-Sent Events handlers. Handlers return `Sse<impl Stream<Item = Result<Event, Infallible>>>` (or the `SseResult` type alias) and are served over GET as `text/event-stream`. Exposes `Sse`, `Event`, `KeepAlive`, `SseResult`, and the `stream`/`try_stream` macros via `sword::web`. Note that the global `request-timeout` layer will terminate long-lived SSE connections when enabled.
+
 - `SwordServiceRegistrar` — auto-registration system for services (parallel to `SwordLayerRegistrar`). Services are mounted directly into the router via `inventory`, not layered.
 - `ServeDir` now auto-registers via `SwordServiceRegistrar` when `sword-layers/servedir` is enabled. It nests at the configured `router-path` (default `/static`) without manual setup.
 - Route macros (`#[get]`, `#[post]`, etc.) now auto-detect the return type and wrap `Ok(T)` in `JsonResponse` with the correct status code (POST=201, other methods=200). Supports `Result<T, JsonResponse>`, `WebResult<T>`, and plain return types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `#[sse]` route attribute for Server-Sent Events handlers. Handlers return `Sse<impl Stream<Item = Result<Event, Infallible>>>` (or the `SseResult` type alias) and are served over GET as `text/event-stream`. Exposes `Sse`, `Event`, `KeepAlive`, `SseResult`, and the `stream`/`try_stream` macros via `sword::web`. Note that the global `request-timeout` layer will terminate long-lived SSE connections when enabled.
+- `#[sse]` route attribute for Server-Sent Events handlers. Handlers return `Sse<impl EventStream + use<>>` (the `EventStream` marker trait covers `Stream<Item = Result<Event, Infallible>> + Send + 'static`) and are served over GET as `text/event-stream`. The concrete stream is returned without boxing, so SSE handlers allocate no heap memory. Exposes `Sse`, `Event`, `KeepAlive`, and the `stream`/`try_stream` macros via `sword::web`. Note that the global `request-timeout` layer will terminate long-lived SSE connections when enabled.
 
 - `SwordServiceRegistrar` — auto-registration system for services (parallel to `SwordLayerRegistrar`). Services are mounted directly into the router via `inventory`, not layered.
 - `ServeDir` now auto-registers via `SwordServiceRegistrar` when `sword-layers/servedir` is enabled. It nests at the configured `router-path` (default `/static`) without manual setup.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,6 +3381,7 @@ dependencies = [
 name = "sword-web"
 version = "0.3.0"
 dependencies = [
+ "async-stream",
  "axum",
  "axum-test",
  "bytes",
@@ -3397,6 +3398,7 @@ dependencies = [
  "sword-macros",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tower",
  "tower-http",
  "tracing",
@@ -3408,6 +3410,7 @@ dependencies = [
 name = "sword-web-example"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "bcrypt",
  "dotenv",
  "serde",
@@ -3416,6 +3419,7 @@ dependencies = [
  "sword",
  "sword-layers",
  "thiserror",
+ "tokio",
  "tracing",
  "uuid",
  "validator",
@@ -3434,6 +3438,7 @@ dependencies = [
  "sword-layers",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tower-http",
  "validator",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ axum_responses = "0.5.5"
 tower = "0.5.2"
 http = "1.2.0"
 
+async-stream = "0.3.6"
 serde_json = "1.0.140"
 regex-lite = "0.1.7"
 

--- a/crates/sword-macros/src/controllers/web/attributes/generation.rs
+++ b/crates/sword-macros/src/controllers/web/attributes/generation.rs
@@ -47,7 +47,9 @@ impl WebRouteGenerator {
         let routing_fn = self.route.method.routing_fn_tokens();
         let call_parts = HandlerCallParts::from_function(&self.route.function);
 
-        let handler_body = if self.route.is_result_return {
+        let handler_body = if self.route.method.is_sse() {
+            self.build_sse_handler_body(&call_parts)
+        } else if self.route.is_result_return {
             self.build_result_handler_body(&call_parts)
         } else {
             self.build_plain_handler_body(&call_parts)
@@ -72,6 +74,37 @@ impl WebRouteGenerator {
                         #handler_body
                     }
                 })
+            }
+        }
+    }
+
+    fn build_sse_handler_body(&self, call_parts: &HandlerCallParts) -> TokenStream {
+        let fn_name = &call_parts.fn_name;
+        let call_args = &call_parts.call_args;
+
+        let call = if call_parts.has_params() {
+            quote! { ctrl.#fn_name(#(#call_args),*).await }
+        } else {
+            quote! { ctrl.#fn_name().await }
+        };
+
+        if self.route.is_result_return {
+            quote! {
+                match #call {
+                    Ok(__data) => {
+                        use ::sword::internal::web::IntoResponse;
+                        __data.into_response()
+                    }
+                    Err(__err) => {
+                        use ::sword::internal::web::IntoResponse;
+                        __err.into_response()
+                    }
+                }
+            }
+        } else {
+            quote! {
+                use ::sword::internal::web::IntoResponse;
+                #call.into_response()
             }
         }
     }

--- a/crates/sword-macros/src/controllers/web/attributes/parsing.rs
+++ b/crates/sword-macros/src/controllers/web/attributes/parsing.rs
@@ -19,7 +19,7 @@ pub enum ReturnKind {
     Empty,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum HttpMethod {
     Get,
     Post,
@@ -30,6 +30,7 @@ pub enum HttpMethod {
     Options,
     Trace,
     Connect,
+    Sse,
 }
 
 impl HttpMethod {
@@ -44,6 +45,7 @@ impl HttpMethod {
             "OPTIONS" => Ok(Self::Options),
             "TRACE" => Ok(Self::Trace),
             "CONNECT" => Ok(Self::Connect),
+            "SSE" => Ok(Self::Sse),
             _ => Err(syn::Error::new(
                 Span::call_site(),
                 format!("Unsupported HTTP method `{method}`"),
@@ -62,6 +64,7 @@ impl HttpMethod {
             Self::Options => "OPTIONS",
             Self::Trace => "TRACE",
             Self::Connect => "CONNECT",
+            Self::Sse => "SSE",
         }
     }
 
@@ -76,6 +79,7 @@ impl HttpMethod {
             Self::Options => quote! { options },
             Self::Trace => quote! { trace },
             Self::Connect => quote! { connect },
+            Self::Sse => quote! { get },
         }
     }
 
@@ -84,6 +88,14 @@ impl HttpMethod {
             Self::Post => 201,
             _ => 200,
         }
+    }
+
+    /// Whether the route is a Server-Sent Events stream.
+    ///
+    /// SSE routes are served over GET but must remain streaming responses, so the
+    /// generator treats them as passthrough regardless of the return type.
+    pub fn is_sse(self) -> bool {
+        matches!(self, Self::Sse)
     }
 }
 
@@ -330,7 +342,7 @@ impl ParsedRouteAttribute {
                     return ReturnKind::Serialize;
                 };
                 match last_segment.ident.to_string().as_str() {
-                    "JsonResponse" | "File" | "Redirect" => ReturnKind::Passthrough,
+                    "JsonResponse" | "File" | "Redirect" | "Sse" => ReturnKind::Passthrough,
                     _ => ReturnKind::Serialize,
                 }
             }

--- a/crates/sword-macros/src/lib.rs
+++ b/crates/sword-macros/src/lib.rs
@@ -69,9 +69,41 @@ pub fn connect(attr: TokenStream, item: TokenStream) -> TokenStream {
     controllers::web::attributes::attribute("CONNECT", attr, item)
 }
 
+#[cfg(feature = "web-controllers")]
+/// Marks a handler as a Server-Sent Events (SSE) route.
+///
+/// The handler must return an `axum::response::Sse` response (see `SseResult`),
+/// typically as `Sse<impl Stream<Item = Result<Event, Infallible>>>`. The route is
+/// served over `GET` with `text/event-stream` content type.
+///
+/// ```rust,ignore
+/// use std::convert::Infallible;
+/// use sword::web::*;
+/// use tokio_stream::{Stream, StreamExt};
+///
+/// #[controller(kind = Controller::Web, path = "/sse")]
+/// struct SseController;
+///
+/// impl SseController {
+///     #[sse("/clock")]
+///     async fn clock(&self) -> Sse<impl Stream<Item = Result<Event, Infallible>> + use<>> {
+///         let stream = tokio_stream::iter(0..5).map(|i| Ok(Event::default().event("tick").data(i.to_string())));
+///         Sse::new(stream)
+///     }
+/// }
+/// ```
+///
+/// > **Note:** SSE connections are long-lived. If `request-timeout` is enabled in the
+/// > application config, the global timeout layer will terminate the stream, so leave it
+/// > disabled or set a generous timeout for streaming routes.
+#[proc_macro_attribute]
+pub fn sse(attr: TokenStream, item: TokenStream) -> TokenStream {
+    controllers::web::attributes::attribute("SSE", attr, item)
+}
+
 /// Defines a Sword controller.
 /// Route handlers are declared directly inside the `impl` block using method attributes
-/// such as `#[get]`, `#[post]`, `#[put]`, `#[patch]`, `#[delete]`, `#[head]`, `#[options]`, `#[trace]`, and `#[connect]`.
+/// such as `#[get]`, `#[post]`, `#[put]`, `#[patch]`, `#[delete]`, `#[head]`, `#[options]`, `#[trace]`, `#[connect]`, and `#[sse]`.
 ///
 /// ### Parameters
 /// - `kind`: Controller kind. Use `Controller::Web`, `Controller::SocketIo`, `Controller::Grpc`, or `Controller::EventHandler`.

--- a/crates/sword-macros/src/lib.rs
+++ b/crates/sword-macros/src/lib.rs
@@ -72,12 +72,11 @@ pub fn connect(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[cfg(feature = "web-controllers")]
 /// Marks a handler as a Server-Sent Events (SSE) route.
 ///
-/// The handler must return an `axum::response::Sse` response (see `SseResult`),
-/// typically as `Sse<impl Stream<Item = Result<Event, Infallible>>>`. The route is
-/// served over `GET` with `text/event-stream` content type.
+/// The handler must return an `Sse` response wrapping a stream, typically as
+/// `Sse<impl EventStream + use<>>`. The route is served over `GET` with
+/// `text/event-stream` content type.
 ///
 /// ```rust,ignore
-/// use std::convert::Infallible;
 /// use sword::web::*;
 /// use tokio_stream::{Stream, StreamExt};
 ///
@@ -86,7 +85,7 @@ pub fn connect(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// impl SseController {
 ///     #[sse("/clock")]
-///     async fn clock(&self) -> Sse<impl Stream<Item = Result<Event, Infallible>> + use<>> {
+///     async fn clock(&self) -> Sse<impl EventStream + use<>> {
 ///         let stream = tokio_stream::iter(0..5).map(|i| Ok(Event::default().event("tick").data(i.to_string())));
 ///         Sse::new(stream)
 ///     }

--- a/crates/sword-web/Cargo.toml
+++ b/crates/sword-web/Cargo.toml
@@ -19,16 +19,17 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 tokio = { workspace = true }
-axum = { workspace = true }
+tokio-stream = { workspace = true }
 
+axum = { workspace = true }
 sword-core = { workspace = true }
 sword-macros = { workspace = true, features = ["web-controllers"] }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
+
 thiserror = { workspace = true }
 chrono = { workspace = true }
-
 form_urlencoded = { workspace = true }
 serde_urlencoded = { workspace = true }
 mime = { workspace = true }
@@ -41,6 +42,7 @@ tracing = { workspace = true }
 inventory = { workspace = true }
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"], optional = true }
 tower = { workspace = true }
+async-stream = { workspace = true }
 
 [dependencies.sword-layers]
 workspace = true

--- a/crates/sword-web/src/controller.rs
+++ b/crates/sword-web/src/controller.rs
@@ -1,6 +1,8 @@
 use sword_core::ControllerSpec;
 
-pub use sword_macros::{connect, controller, delete, get, head, options, patch, post, put, trace};
+pub use sword_macros::{
+    connect, controller, delete, get, head, options, patch, post, put, sse, trace,
+};
 
 /// Trait for controllers with automatic dependency injection and interceptors support.
 ///

--- a/crates/sword-web/src/lib.rs
+++ b/crates/sword-web/src/lib.rs
@@ -14,8 +14,8 @@ pub mod prelude {
     };
     pub use crate::request::{Request, RequestError, StreamRequest};
     pub use crate::response::{
-        ContentDisposition, Event, File, HttpError, JsonResponse, JsonResponseBody, KeepAlive,
-        Redirect, Sse, SseResult, WebResult,
+        ContentDisposition, Event, EventStream, File, HttpError, JsonResponse, JsonResponseBody,
+        KeepAlive, Redirect, Sse, WebResult,
     };
     pub use async_stream::{stream, try_stream};
     pub use axum::middleware::Next;

--- a/crates/sword-web/src/lib.rs
+++ b/crates/sword-web/src/lib.rs
@@ -6,7 +6,7 @@ pub mod response;
 
 pub mod prelude {
     pub use crate::controller::{
-        WebController, connect, delete, get, head, options, patch, post, put, trace,
+        WebController, connect, delete, get, head, options, patch, post, put, sse, trace,
     };
     pub use crate::interceptor::{
         OnRequest, OnRequestStream, OnRequestStreamWithConfig, OnRequestWithConfig,
@@ -14,8 +14,10 @@ pub mod prelude {
     };
     pub use crate::request::{Request, RequestError, StreamRequest};
     pub use crate::response::{
-        ContentDisposition, File, HttpError, JsonResponse, JsonResponseBody, Redirect, WebResult,
+        ContentDisposition, Event, File, HttpError, JsonResponse, JsonResponseBody, KeepAlive,
+        Redirect, Sse, SseResult, WebResult,
     };
+    pub use async_stream::{stream, try_stream};
     pub use axum::middleware::Next;
 
     #[cfg(feature = "validation-validator")]

--- a/crates/sword-web/src/response/mod.rs
+++ b/crates/sword-web/src/response/mod.rs
@@ -1,12 +1,14 @@
 mod file;
 mod json;
 mod redirect;
+mod sse;
 
 use crate::request::RequestError;
 
 pub use file::*;
 pub use json::{JsonResponse, JsonResponseBody};
 pub use redirect::Redirect;
+pub use sse::*;
 pub use sword_macros::HttpError;
 
 pub type WebResult<T = JsonResponse, E = JsonResponse> = Result<T, E>;

--- a/crates/sword-web/src/response/sse.rs
+++ b/crates/sword-web/src/response/sse.rs
@@ -1,13 +1,12 @@
 //! Server-Sent Events (SSE) support.
 //!
 //! Re-exports axum's [`Sse`], [`Event`], and [`KeepAlive`] types, the
-//! `stream!` / `try_stream!` macros from `async_stream`, and provides the
-//! [`SseResult`] type alias for ergonomic SSE handler return types.
+//! `stream!` / `try_stream!` macros from `async_stream`, and defines the
+//! [`EventStream`] marker trait for SSE handler return types.
 //!
 //! Use the `#[sse]` route attribute to expose an SSE stream:
 //!
 //! ```rust,ignore
-//! use std::convert::Infallible;
 //! use sword::web::*;
 //! use tokio_stream::{Stream, StreamExt};
 //!
@@ -16,7 +15,7 @@
 //!
 //! impl SseController {
 //!     #[sse("/clock")]
-//!     async fn clock(&self) -> Sse<impl Stream<Item = Result<Event, Infallible>> + use<>> {
+//!     async fn clock(&self) -> Sse<impl EventStream + use<>> {
 //!         Sse::new(tokio_stream::iter(0..5).map(|i| {
 //!             Ok(Event::default().event("tick").data(i.to_string()))
 //!         }))
@@ -28,11 +27,18 @@
 //! > application config, the global timeout layer will terminate the stream, so leave it
 //! > disabled or set a generous timeout for streaming routes.
 
-use std::{convert::Infallible, pin::Pin};
+use std::convert::Infallible;
 use tokio_stream::Stream;
 
 pub use async_stream::{stream, try_stream};
 pub use axum::response::sse::{Event, KeepAlive, Sse};
 
-pub type SseResult<T = Event> =
-    axum::response::Sse<Pin<Box<dyn Stream<Item = Result<T, Infallible>> + Send>>>;
+/// A stream of Server-Sent Events.
+///
+/// Marker trait for any `Stream<Item = Result<Event, Infallible>> + Send + 'static`.
+/// These are exactly the bounds axum requires for `Sse<S>: IntoResponse`, so a
+/// handler returning `Sse<impl EventStream + use<>>` is always a valid SSE response
+/// without boxing the stream or naming its concrete type.
+pub trait EventStream: Stream<Item = Result<Event, Infallible>> + Send + 'static {}
+
+impl<S> EventStream for S where S: Stream<Item = Result<Event, Infallible>> + Send + 'static {}

--- a/crates/sword-web/src/response/sse.rs
+++ b/crates/sword-web/src/response/sse.rs
@@ -1,0 +1,38 @@
+//! Server-Sent Events (SSE) support.
+//!
+//! Re-exports axum's [`Sse`], [`Event`], and [`KeepAlive`] types, the
+//! `stream!` / `try_stream!` macros from `async_stream`, and provides the
+//! [`SseResult`] type alias for ergonomic SSE handler return types.
+//!
+//! Use the `#[sse]` route attribute to expose an SSE stream:
+//!
+//! ```rust,ignore
+//! use std::convert::Infallible;
+//! use sword::web::*;
+//! use tokio_stream::{Stream, StreamExt};
+//!
+//! #[controller(kind = Controller::Web, path = "/sse")]
+//! struct SseController;
+//!
+//! impl SseController {
+//!     #[sse("/clock")]
+//!     async fn clock(&self) -> Sse<impl Stream<Item = Result<Event, Infallible>> + use<>> {
+//!         Sse::new(tokio_stream::iter(0..5).map(|i| {
+//!             Ok(Event::default().event("tick").data(i.to_string()))
+//!         }))
+//!     }
+//! }
+//! ```
+//!
+//! > **Note:** SSE connections are long-lived. If `request-timeout` is enabled in the
+//! > application config, the global timeout layer will terminate the stream, so leave it
+//! > disabled or set a generous timeout for streaming routes.
+
+use std::{convert::Infallible, pin::Pin};
+use tokio_stream::Stream;
+
+pub use async_stream::{stream, try_stream};
+pub use axum::response::sse::{Event, KeepAlive, Sse};
+
+pub type SseResult<T = Event> =
+    axum::response::Sse<Pin<Box<dyn Stream<Item = Result<T, Infallible>> + Send>>>;

--- a/examples/grpc/Cargo.toml
+++ b/examples/grpc/Cargo.toml
@@ -12,7 +12,7 @@ prost = "0.14.1"
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-async-stream = "0.3.6"
+async-stream = { workspace = true }
 
 [build-dependencies]
 tonic-prost-build = "0.14.2"

--- a/examples/web/Cargo.toml
+++ b/examples/web/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2024"
 sword = { workspace = true, features = ["web", "validation-validator", "web-swagger-ui", "events-in-memory"] }
 sword-layers = { workspace = true, features = ["compression", "cors",  "servedir"] }
 
+async-stream = { workspace = true }
+tokio = { workspace = true }
+
 serde = { workspace = true }
 validator = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -10,3 +10,15 @@ This example demonstrates a user management API using Sword's web controllers. I
 4. Run the application: `cargo run`
 
 The API will be available at http://localhost:8081/api/users.
+
+## Server-Sent Events
+
+The example also exposes an SSE stream at `GET /api/sse/countdown`:
+
+```bash
+curl -N http://localhost:8081/api/sse/countdown
+```
+
+This returns a `text/event-stream` response with a `countdown` event every 250ms followed by a final `done` event.
+
+> **Note:** SSE connections are long-lived. If `request-timeout` is enabled in your config, the global timeout layer will terminate the stream, so leave it disabled or set a generous timeout for routes that stream events.

--- a/examples/web/src/main.rs
+++ b/examples/web/src/main.rs
@@ -1,11 +1,12 @@
 pub mod mailer;
 pub mod shared;
+pub mod sse;
 pub mod users;
 
 use dotenv::dotenv;
 use sword::prelude::*;
 
-use crate::{mailer::MailerModule, shared::SharedModule, users::UsersModule};
+use crate::{mailer::MailerModule, shared::SharedModule, sse::SseModule, users::UsersModule};
 
 #[sword::main]
 async fn main() {
@@ -17,6 +18,7 @@ async fn main() {
         .with_module::<SharedModule>()
         .with_module::<UsersModule>()
         .with_module::<MailerModule>()
+        .with_module::<SseModule>()
         .build();
 
     app.run().await;

--- a/examples/web/src/sse/controller.rs
+++ b/examples/web/src/sse/controller.rs
@@ -1,6 +1,7 @@
-use std::time::Duration;
-
 use async_stream::stream;
+use std::time::Duration;
+use tokio::time::sleep;
+
 use sword::prelude::*;
 use sword::web::*;
 
@@ -9,15 +10,16 @@ pub struct SseController;
 
 impl SseController {
     #[sse("/countdown")]
-    async fn countdown(&self) -> SseResult {
+    async fn countdown(&self) -> Sse<impl EventStream + use<>> {
         let events = stream! {
             for i in (1..=5).rev() {
-                tokio::time::sleep(Duration::from_millis(250)).await;
+                sleep(Duration::from_millis(250)).await;
                 yield Ok(Event::default().event("countdown").data(i.to_string()));
             }
-            yield Ok(Event::default().event("done").data("lift off!"));
+
+            yield Ok(Event::default().event("done").data("The countdown has finished!"));
         };
 
-        Sse::new(Box::pin(events))
+        Sse::new(events)
     }
 }

--- a/examples/web/src/sse/controller.rs
+++ b/examples/web/src/sse/controller.rs
@@ -1,0 +1,23 @@
+use std::time::Duration;
+
+use async_stream::stream;
+use sword::prelude::*;
+use sword::web::*;
+
+#[controller(kind = Controller::Web, path = "/sse")]
+pub struct SseController;
+
+impl SseController {
+    #[sse("/countdown")]
+    async fn countdown(&self) -> SseResult {
+        let events = stream! {
+            for i in (1..=5).rev() {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                yield Ok(Event::default().event("countdown").data(i.to_string()));
+            }
+            yield Ok(Event::default().event("done").data("lift off!"));
+        };
+
+        Sse::new(Box::pin(events))
+    }
+}

--- a/examples/web/src/sse/mod.rs
+++ b/examples/web/src/sse/mod.rs
@@ -1,0 +1,13 @@
+mod controller;
+
+use controller::SseController;
+
+use sword::prelude::*;
+
+pub struct SseModule;
+
+impl Module for SseModule {
+    fn register_controllers(controllers: &ControllerRegistry) {
+        controllers.register::<SseController>();
+    }
+}

--- a/tests/sword-web/Cargo.toml
+++ b/tests/sword-web/Cargo.toml
@@ -9,6 +9,7 @@ sword = { workspace = true, features = ["web", "web-multipart", "validation-vali
 sword-layers = { workspace = true, features = ["helmet", "compression"] }
 tokio = { workspace = true }
 axum = { workspace = true }
+tokio-stream = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/tests/sword-web/src/lib.rs
+++ b/tests/sword-web/src/lib.rs
@@ -23,6 +23,9 @@ mod errors;
 mod http_methods;
 
 #[cfg(test)]
+mod sse;
+
+#[cfg(test)]
 mod return_type;
 
 #[cfg(test)]

--- a/tests/sword-web/src/sse.rs
+++ b/tests/sword-web/src/sse.rs
@@ -1,0 +1,46 @@
+use std::convert::Infallible;
+
+use sword::prelude::*;
+use sword::web::*;
+use tokio_stream::{Stream, StreamExt};
+
+use crate::application_builder;
+use crate::test_server;
+
+#[controller(kind = Controller::Web, path = "/sse")]
+pub struct SseController;
+
+impl SseController {
+    #[sse("/stream")]
+    async fn stream(&self) -> Sse<impl Stream<Item = Result<Event, Infallible>> + use<>> {
+        let events = vec![
+            Event::default().event("greeting").data("one"),
+            Event::default().event("greeting").data("two"),
+        ];
+
+        Sse::new(tokio_stream::iter(events).map(Ok))
+    }
+}
+
+struct SseModule;
+
+impl Module for SseModule {
+    fn register_controllers(controllers: &ControllerRegistry) {
+        controllers.register::<SseController>();
+    }
+}
+
+#[tokio::test]
+async fn sse_handler_streams_events() {
+    let app = application_builder().with_module::<SseModule>().build();
+    let app = test_server(app);
+
+    let response = app.get("/sse/stream").await;
+    assert_eq!(response.status_code().as_u16(), 200);
+    assert_eq!(response.content_type(), "text/event-stream");
+
+    let body = response.text();
+    assert!(body.contains("event: greeting"), "body: {body}");
+    assert!(body.contains("data: one"), "body: {body}");
+    assert!(body.contains("data: two"), "body: {body}");
+}

--- a/tests/sword-web/src/sse.rs
+++ b/tests/sword-web/src/sse.rs
@@ -1,8 +1,6 @@
-use std::convert::Infallible;
-
 use sword::prelude::*;
 use sword::web::*;
-use tokio_stream::{Stream, StreamExt};
+use tokio_stream::StreamExt;
 
 use crate::application_builder;
 use crate::test_server;
@@ -12,13 +10,23 @@ pub struct SseController;
 
 impl SseController {
     #[sse("/stream")]
-    async fn stream(&self) -> Sse<impl Stream<Item = Result<Event, Infallible>> + use<>> {
+    async fn stream(&self) -> Sse<impl EventStream + use<>> {
         let events = vec![
             Event::default().event("greeting").data("one"),
             Event::default().event("greeting").data("two"),
         ];
 
         Sse::new(tokio_stream::iter(events).map(Ok))
+    }
+
+    #[sse("/keep-alive")]
+    async fn keep_alive(&self) -> Sse<impl EventStream + use<>> {
+        let events = vec![
+            Event::default().event("greeting").data("one"),
+            Event::default().event("greeting").data("two"),
+        ];
+
+        Sse::new(tokio_stream::iter(events).map(Ok)).keep_alive(KeepAlive::default())
     }
 }
 
@@ -36,6 +44,21 @@ async fn sse_handler_streams_events() {
     let app = test_server(app);
 
     let response = app.get("/sse/stream").await;
+    assert_eq!(response.status_code().as_u16(), 200);
+    assert_eq!(response.content_type(), "text/event-stream");
+
+    let body = response.text();
+    assert!(body.contains("event: greeting"), "body: {body}");
+    assert!(body.contains("data: one"), "body: {body}");
+    assert!(body.contains("data: two"), "body: {body}");
+}
+
+#[tokio::test]
+async fn sse_handler_keep_alive_composes() {
+    let app = application_builder().with_module::<SseModule>().build();
+    let app = test_server(app);
+
+    let response = app.get("/sse/keep-alive").await;
     assert_eq!(response.status_code().as_u16(), 200);
     assert_eq!(response.content_type(), "text/event-stream");
 


### PR DESCRIPTION
This PR adds axum's SSE integration to sword-web.

Code example:

```rust
use async_stream::stream;
use std::time::Duration;
use tokio::time::sleep;

use sword::prelude::*;
use sword::web::*;

#[controller(kind = Controller::Web, path = "/sse")]
pub struct SseController;

impl SseController {
    #[sse("/countdown")]
    async fn countdown(&self) -> SseResult {
        let events = stream! {
            for i in (1..=5).rev() {
                sleep(Duration::from_millis(250)).await;
                yield Ok(Event::default().event("countdown").data(i.to_string()));
            }

            yield Ok(Event::default().event("done").data("The countdown has finished!"));
        };

        Sse::new(Box::pin(events))
    }
}
```

Note: the built-in Timeout layer will terminate long-lived streams, so increase or disable request-timeout when using SSE.