### PR TITLE
ci: make release-plz releases explicit

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,7 @@ name: Release-plz
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: release-plz-${{ github.ref }}
@@ -10,6 +11,7 @@ concurrency:
 
 jobs:
   release-plz-pr:
+    if: github.event_name == 'workflow_dispatch'
     name: Release-plz PR
     runs-on: ubuntu-latest
     permissions:
@@ -31,6 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-plz-release:
+    if: github.event_name == 'push'
     name: Release-plz release
     runs-on: ubuntu-latest
     permissions:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,4 +1,5 @@
 [workspace]
+release_always = false
 
 [[package]]
 name = "interceptors"


### PR DESCRIPTION
### Make releases explicit instead of automatic

Release-plz was releasing on every merge to main, which created a version bump PR (and a release) for every PR merged. This makes releases an explicit, manual action while keeping the publish step automatic.