### PR TITLE
feat(grpc): GrpcStatus richer errors + tonic 0.14.6 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `GrpcStatus` — buildable gRPC status implementing the Richer Error Model, gated behind the `grpc-error-details` feature. It provides an associated function per status code (`GrpcStatus::InvalidArgument()`, `GrpcStatus::NotFound()`, ...) plus chainable detail builders (`bad_request`, `localized_message`, `error_info`, `retry_after`, `help`, `debug_info`, `precondition_failure`, `quota_failure`, `request_info`, `resource_info`) and converts into `tonic::Status` via `.into()`/`build()`. `GrpcStatus::from_status` reconstructs a status client-side. Requires the `grpc-error-details` feature on the `sword` facade (`tonic-types` is re-exported alongside `StatusExt`/`ErrorDetails`).
+
 - `#[sse]` route attribute for Server-Sent Events handlers. Handlers return `Sse<impl EventStream + use<>>` (the `EventStream` marker trait covers `Stream<Item = Result<Event, Infallible>> + Send + 'static`) and are served over GET as `text/event-stream`. The concrete stream is returned without boxing, so SSE handlers allocate no heap memory. Exposes `Sse`, `Event`, `KeepAlive`, and the `stream`/`try_stream` macros via `sword::web`. Note that the global `request-timeout` layer will terminate long-lived SSE connections when enabled.
 
 - `SwordServiceRegistrar` — auto-registration system for services (parallel to `SwordLayerRegistrar`). Services are mounted directly into the router via `inventory`, not layered.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -719,11 +719,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -733,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -2138,25 +2137,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3257,6 +3256,7 @@ dependencies = [
  "tonic-async-interceptor",
  "tonic-health",
  "tonic-reflection",
+ "tonic-types",
  "tracing",
 ]
 
@@ -3266,6 +3266,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "prost",
+ "prost-types",
  "sword",
  "thiserror",
  "tokio",
@@ -3462,6 +3463,16 @@ checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
  "unicode-ident",
 ]
 
@@ -3847,6 +3858,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4192,13 +4214,12 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+checksum = "240e4b81c20a1d6d50d1d7265c658dfbd204e8b9ac4d80f3c931f39462196335"
 dependencies = [
  "darling",
- "once_cell",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.metadata.cargo-machete]
-ignored  = ["prost",  "tonic-prost"]
+ignored  = ["prost", "prost-types", "tonic-prost"]
 
 [workspace.package]
 version = "0.3.0"
@@ -32,11 +32,13 @@ sword-events = { path = "crates/sword-events", version = "0.3.0" }
 
 tokio = { version = "^1.0", features = ["full"] }
 tokio-stream = "0.1.18"
-tonic = "0.14.5"
-tonic-prost = "0.14.5"
+tonic = "0.14.6"
+tonic-prost = "0.14.6"
+tonic-types = "0.14.6"
+tonic-prost-build = "0.14.6"
 tonic-async-interceptor = "0.14.1"
-tonic-health = "0.14.2"
-tonic-reflection = "0.14.2"
+tonic-health = "0.14.6"
+tonic-reflection = "0.14.6"
 serde = { version = "1.0.219", features = ["derive"] }
 
 axum = "0.8.7"

--- a/crates/sword-grpc/Cargo.toml
+++ b/crates/sword-grpc/Cargo.toml
@@ -22,6 +22,7 @@ tonic = { workspace = true }
 tonic-async-interceptor = { workspace = true }
 tonic-health = { workspace = true }
 tonic-reflection = { workspace = true, optional = true }
+tonic-types = { workspace = true, optional = true }
 tokio-stream = { workspace = true }
 serde = { workspace = true }
 
@@ -35,3 +36,4 @@ inventory = { workspace = true }
 [features]
 default = []
 reflection = ["dep:tonic-reflection", "sword-macros/grpc-reflection"]
+error-details = ["dep:tonic-types"]

--- a/crates/sword-grpc/src/lib.rs
+++ b/crates/sword-grpc/src/lib.rs
@@ -13,12 +13,23 @@ pub mod prelude {
     pub use tonic::{
         Code, Extensions, Request, Response, Status, Streaming, async_trait, include_proto,
     };
+
+    #[cfg(feature = "error-details")]
+    pub use crate::response::GrpcStatus;
+    #[cfg(feature = "error-details")]
+    pub use tonic_types::{
+        BadRequest, DebugInfo, ErrorDetail, ErrorDetails, ErrorInfo, FieldViolation, Help,
+        HelpLink, LocalizedMessage, PreconditionFailure, PreconditionViolation, QuotaFailure,
+        QuotaViolation, RequestInfo, ResourceInfo, RetryInfo, StatusExt,
+    };
 }
 
 #[doc(hidden)]
 pub mod internal {
     pub use tonic;
     pub use tonic_async_interceptor;
+    #[cfg(feature = "error-details")]
+    pub use tonic_types;
 
     pub use crate::controller::{GrpcController, GrpcControllerRegistrar};
     pub use crate::registry::GrpcServiceRegistry;

--- a/crates/sword-grpc/src/response.rs
+++ b/crates/sword-grpc/src/response.rs
@@ -18,3 +18,264 @@ impl GrpcResponse {
         tonic::Response::new(Box::pin(stream))
     }
 }
+
+#[cfg(feature = "error-details")]
+mod grpc_status {
+    use std::collections::HashMap;
+    use tonic::Code;
+    use tonic_types::{ErrorDetails, StatusExt};
+
+    /// A buildable gRPC status implementing the [gRPC Richer Error Model].
+    ///
+    /// Construct it with an associated function per status code (e.g.
+    /// [`GrpcStatus::InvalidArgument`]) and chain detail builders before
+    /// converting it into a [`tonic::Status`] with `.into()` or [`build`].
+    ///
+    /// Error details are applicable to any status code: the gRPC standard
+    /// recommends pairings but does not enforce them.
+    ///
+    /// ```rust,ignore
+    /// use sword::grpc::*;
+    ///
+    /// let status: tonic::Status = GrpcStatus::InvalidArgument()
+    ///     .message("invalid request")
+    ///     .bad_request("username", "username cannot be empty")
+    ///     .into();
+    /// ```
+    ///
+    /// [gRPC Richer Error Model]: https://grpc.io/docs/guides/error/
+    /// [`build`]: GrpcStatus::build
+    #[derive(Debug, Clone)]
+    pub struct GrpcStatus {
+        code: Code,
+        message: String,
+        details: ErrorDetails,
+    }
+
+    macro_rules! code_constructor {
+        ($(#[$doc:meta] $name:ident => $code:expr),* $(,)?) => {
+            $(
+                #[$doc]
+                pub fn $name() -> Self {
+                    Self::new($code)
+                }
+            )*
+        };
+    }
+
+    #[allow(non_snake_case)]
+    impl GrpcStatus {
+        code_constructor! {
+            /// Creates a `GrpcStatus` with code `Ok`.
+            Ok => Code::Ok,
+            /// Creates a `GrpcStatus` with code `Cancelled`.
+            Cancelled => Code::Cancelled,
+            /// Creates a `GrpcStatus` with code `Unknown`.
+            Unknown => Code::Unknown,
+            /// Creates a `GrpcStatus` with code `InvalidArgument`.
+            InvalidArgument => Code::InvalidArgument,
+            /// Creates a `GrpcStatus` with code `DeadlineExceeded`.
+            DeadlineExceeded => Code::DeadlineExceeded,
+            /// Creates a `GrpcStatus` with code `NotFound`.
+            NotFound => Code::NotFound,
+            /// Creates a `GrpcStatus` with code `AlreadyExists`.
+            AlreadyExists => Code::AlreadyExists,
+            /// Creates a `GrpcStatus` with code `PermissionDenied`.
+            PermissionDenied => Code::PermissionDenied,
+            /// Creates a `GrpcStatus` with code `ResourceExhausted`.
+            ResourceExhausted => Code::ResourceExhausted,
+            /// Creates a `GrpcStatus` with code `FailedPrecondition`.
+            FailedPrecondition => Code::FailedPrecondition,
+            /// Creates a `GrpcStatus` with code `Aborted`.
+            Aborted => Code::Aborted,
+            /// Creates a `GrpcStatus` with code `OutOfRange`.
+            OutOfRange => Code::OutOfRange,
+            /// Creates a `GrpcStatus` with code `Unimplemented`.
+            Unimplemented => Code::Unimplemented,
+            /// Creates a `GrpcStatus` with code `Internal`.
+            Internal => Code::Internal,
+            /// Creates a `GrpcStatus` with code `Unavailable`.
+            Unavailable => Code::Unavailable,
+            /// Creates a `GrpcStatus` with code `DataLoss`.
+            DataLoss => Code::DataLoss,
+            /// Creates a `GrpcStatus` with code `Unauthenticated`.
+            Unauthenticated => Code::Unauthenticated,
+        }
+
+        /// Creates a `GrpcStatus` from a `tonic::Code` with the code's canonical
+        /// message and no details. Override the message with [`message`].
+        ///
+        /// [`message`]: GrpcStatus::message
+        pub fn new(code: Code) -> Self {
+            Self {
+                code,
+                message: code.to_string(),
+                details: ErrorDetails::new(),
+            }
+        }
+
+        /// Sets the status message.
+        pub fn message(mut self, message: impl Into<String>) -> Self {
+            self.message = message.into();
+            self
+        }
+
+        /// Adds a [`BadRequest`] field violation.
+        ///
+        /// [`BadRequest`]: tonic_types::BadRequest
+        pub fn bad_request(
+            mut self,
+            field: impl Into<String>,
+            description: impl Into<String>,
+        ) -> Self {
+            self.details.add_bad_request_violation(field, description);
+            self
+        }
+
+        /// Sets a [`LocalizedMessage`] detail.
+        ///
+        /// [`LocalizedMessage`]: tonic_types::LocalizedMessage
+        pub fn localized_message(
+            mut self,
+            locale: impl Into<String>,
+            message: impl Into<String>,
+        ) -> Self {
+            self.details.set_localized_message(locale, message);
+            self
+        }
+
+        /// Sets an [`ErrorInfo`] detail.
+        ///
+        /// [`ErrorInfo`]: tonic_types::ErrorInfo
+        pub fn error_info(
+            mut self,
+            domain: impl Into<String>,
+            reason: impl Into<String>,
+            metadata: HashMap<String, String>,
+        ) -> Self {
+            self.details.set_error_info(reason, domain, metadata);
+            self
+        }
+
+        /// Sets a [`RetryInfo`] detail advising clients to retry after the given delay.
+        ///
+        /// [`RetryInfo`]: tonic_types::RetryInfo
+        pub fn retry_after(mut self, delay: std::time::Duration) -> Self {
+            self.details.set_retry_info(Some(delay));
+            self
+        }
+
+        /// Adds a [`Help`] link.
+        ///
+        /// [`Help`]: tonic_types::Help
+        pub fn help(mut self, description: impl Into<String>, url: impl Into<String>) -> Self {
+            self.details.add_help_link(description, url);
+            self
+        }
+
+        /// Sets a [`DebugInfo`] detail with stack entries and an additional detail string.
+        ///
+        /// [`DebugInfo`]: tonic_types::DebugInfo
+        pub fn debug_info(
+            mut self,
+            stack_entries: impl Into<Vec<String>>,
+            detail: impl Into<String>,
+        ) -> Self {
+            self.details.set_debug_info(stack_entries, detail);
+            self
+        }
+
+        /// Adds a [`PreconditionFailure`] violation.
+        ///
+        /// [`PreconditionFailure`]: tonic_types::PreconditionFailure
+        pub fn precondition_failure(
+            mut self,
+            violation_type: impl Into<String>,
+            subject: impl Into<String>,
+            description: impl Into<String>,
+        ) -> Self {
+            self.details
+                .add_precondition_failure_violation(violation_type, subject, description);
+            self
+        }
+
+        /// Adds a [`QuotaFailure`] violation.
+        ///
+        /// [`QuotaFailure`]: tonic_types::QuotaFailure
+        pub fn quota_failure(
+            mut self,
+            subject: impl Into<String>,
+            description: impl Into<String>,
+        ) -> Self {
+            self.details
+                .add_quota_failure_violation(subject, description);
+            self
+        }
+
+        /// Sets a [`RequestInfo`] detail.
+        ///
+        /// [`RequestInfo`]: tonic_types::RequestInfo
+        pub fn request_info(
+            mut self,
+            request_id: impl Into<String>,
+            serving_data: impl Into<String>,
+        ) -> Self {
+            self.details.set_request_info(request_id, serving_data);
+            self
+        }
+
+        /// Sets a [`ResourceInfo`] detail.
+        ///
+        /// [`ResourceInfo`]: tonic_types::ResourceInfo
+        pub fn resource_info(
+            mut self,
+            resource_type: impl Into<String>,
+            resource_name: impl Into<String>,
+            owner: impl Into<String>,
+            description: impl Into<String>,
+        ) -> Self {
+            self.details
+                .set_resource_info(resource_type, resource_name, owner, description);
+            self
+        }
+
+        /// Builds the `GrpcStatus` into a [`tonic::Status`] with the attached error details.
+        pub fn build(self) -> tonic::Status {
+            <tonic::Status as StatusExt>::with_error_details(self.code, self.message, self.details)
+        }
+
+        /// Reconstructs a `GrpcStatus` from a [`tonic::Status`], extracting its
+        /// code, message, and error details.
+        pub fn from_status(status: &tonic::Status) -> Self {
+            Self {
+                code: status.code(),
+                message: status.message().to_string(),
+                details: status.get_error_details(),
+            }
+        }
+
+        /// Returns the status code.
+        pub fn code(&self) -> Code {
+            self.code
+        }
+
+        /// Returns the status message.
+        pub fn message_text(&self) -> &str {
+            &self.message
+        }
+
+        /// Returns a reference to the error details.
+        pub fn details(&self) -> &ErrorDetails {
+            &self.details
+        }
+    }
+
+    impl From<GrpcStatus> for tonic::Status {
+        fn from(status: GrpcStatus) -> Self {
+            status.build()
+        }
+    }
+}
+
+#[cfg(feature = "error-details")]
+pub use grpc_status::GrpcStatus;

--- a/crates/sword/Cargo.toml
+++ b/crates/sword/Cargo.toml
@@ -44,6 +44,7 @@ web = ["dep:sword-web"]
 socketio = ["web", "dep:sword-socketio"]
 grpc = ["dep:sword-grpc"]
 grpc-reflection = ["dep:sword-grpc", "sword-grpc/reflection"]
+grpc-error-details = ["grpc", "sword-grpc/error-details"]
 
 web-multipart = ["sword-web/multipart"]
 web-swagger-ui = ["sword-web/swagger-ui"]

--- a/examples/grpc/Cargo.toml
+++ b/examples/grpc/Cargo.toml
@@ -4,15 +4,16 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-sword = { workspace = true, features = ["grpc", "grpc-reflection"] }
+sword = { workspace = true, features = ["grpc", "grpc-reflection", "grpc-error-details"] }
 tonic-prost = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 prost = "0.14.1"
+prost-types = "0.14.1"
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 async-stream = { workspace = true }
 
 [build-dependencies]
-tonic-prost-build = "0.14.2"
+tonic-prost-build = { workspace = true }

--- a/examples/grpc/README.md
+++ b/examples/grpc/README.md
@@ -30,3 +30,31 @@ cargo run -p grpc-controllers
 - Server default address is `127.0.0.1:50051`.
 - If the binary is built with the `grpc-reflection` feature, `grpcurl list` includes health and users services.
 - Reflection metadata is registered automatically by Sword from `build.rs` when generating `sword_descriptor_set.bin`.
+
+## Richer errors (feature `grpc-error-details`)
+
+With the `grpc-error-details` feature enabled, handlers can return errors that
+implement the [gRPC Richer Error Model](https://grpc.io/docs/guides/error/)
+using the `GrpcStatus` builder, chaining standard error details on any status
+code:
+
+```rust
+return Err(
+    GrpcStatus::InvalidArgument()
+        .message("invalid request")
+        .bad_request("username", "username cannot be empty")
+        .into(),
+);
+```
+
+Simple errors keep propagating with `?` through the `#[derive(GrpcError)]` type.
+Clients can read the details back with `tonic_types::StatusExt`:
+
+```rust
+use sword::grpc::*;
+
+let details = status.get_error_details();
+if let Some(bad_request) = details.bad_request() {
+    // ...
+}
+```

--- a/examples/grpc/config/proto/users.proto
+++ b/examples/grpc/config/proto/users.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package users;
 
+import "google/protobuf/timestamp.proto";
+
 service UserService {
   rpc ListUsers (ListUsersRequest) returns (ListUsersReply);
   rpc StreamUsers (StreamUsersRequest) returns (stream UserItem);
@@ -14,6 +16,7 @@ service UserService {
 message UserItem {
   string id = 1;
   string username = 2;
+  google.protobuf.Timestamp created_at = 3;
 }
 
 message ListUsersRequest {}

--- a/examples/grpc/src/users/controller.rs
+++ b/examples/grpc/src/users/controller.rs
@@ -1,14 +1,14 @@
-use async_stream::try_stream;
-use std::sync::Arc;
-use sword::grpc::*;
-use sword::prelude::*;
-use tokio::time::{self, Duration};
-
 use crate::shared::LoggingInterceptor;
 use crate::{
     shared::AuthInterceptor,
     users::{CreateUserDto, UpdateUserDto, UserRepository, proto::*},
 };
+
+use async_stream::try_stream;
+use std::sync::Arc;
+use sword::grpc::*;
+use sword::prelude::*;
+use tokio::time::{self, Duration};
 
 #[controller(kind = Controller::Grpc, service = UserServiceServer)]
 #[interceptor(LoggingInterceptor, config = "UsersController")]
@@ -24,13 +24,7 @@ impl UserService for UsersController {
     async fn list_users(&self, _: Request<ListUsersRequest>) -> GrpcResult<ListUsersReply> {
         let users = self.users.find_all().await;
 
-        let users = users
-            .into_iter()
-            .map(|u| UserItem {
-                id: u.id,
-                username: u.username,
-            })
-            .collect();
+        let users = users.into_iter().map(|u| UserItem::from(&u)).collect();
 
         Ok(GrpcResponse::message(ListUsersReply { users }))
     }
@@ -43,10 +37,7 @@ impl UserService for UsersController {
 
         let output = try_stream! {
             for user in users {
-                yield UserItem {
-                    id: user.id,
-                    username: user.username,
-                };
+                yield UserItem::from(&user);
 
                 time::sleep(Duration::from_secs(1)).await;
             }
@@ -58,17 +49,19 @@ impl UserService for UsersController {
     async fn create_user(&self, req: Request<CreateUserRequest>) -> GrpcResult<UserReply> {
         let payload = req.into_inner();
 
+        if payload.username.trim().is_empty() {
+            Err(GrpcStatus::InvalidArgument()
+                .message("invalid request")
+                .bad_request("username", "username cannot be empty"))?
+        }
+
         let dto = CreateUserDto {
             username: payload.username,
             password: payload.password,
         };
 
         let user = self.users.create(dto).await?;
-
-        let user_item = UserItem {
-            id: user.id,
-            username: user.username.clone(),
-        };
+        let user_item = UserItem::from(&user);
 
         Ok(GrpcResponse::message(UserReply {
             user: Some(user_item),
@@ -79,10 +72,7 @@ impl UserService for UsersController {
         let id = req.into_inner().id;
         let user = self.users.find_by_id(&id).await?;
 
-        let user_item = UserItem {
-            id: user.id,
-            username: user.username.clone(),
-        };
+        let user_item = UserItem::from(&user);
 
         Ok(GrpcResponse::message(UserReply {
             user: Some(user_item),
@@ -100,10 +90,7 @@ impl UserService for UsersController {
 
         let user = self.users.update(dto).await?;
 
-        let user_item = UserItem {
-            id: user.id,
-            username: user.username.clone(),
-        };
+        let user_item = UserItem::from(&user);
 
         Ok(GrpcResponse::message(UserReply {
             user: Some(user_item),

--- a/examples/grpc/src/users/entity.rs
+++ b/examples/grpc/src/users/entity.rs
@@ -1,6 +1,19 @@
+use crate::users::proto::UserItem;
+
 #[derive(Clone)]
 pub struct User {
     pub id: String,
     pub username: String,
     pub password: String,
+    pub created_at: prost_types::Timestamp,
+}
+
+impl From<&User> for UserItem {
+    fn from(user: &User) -> Self {
+        UserItem {
+            id: user.id.clone(),
+            username: user.username.clone(),
+            created_at: Some(user.created_at),
+        }
+    }
 }

--- a/examples/grpc/src/users/repository.rs
+++ b/examples/grpc/src/users/repository.rs
@@ -57,6 +57,7 @@ impl UserRepository {
             id,
             username: dto.username,
             password,
+            created_at: prost_types::Timestamp::from(std::time::SystemTime::now()),
         };
 
         self.db.set(user.clone()).await;
@@ -83,6 +84,7 @@ impl UserRepository {
             id: dto.id,
             username,
             password,
+            created_at: existing.created_at,
         };
 
         self.db.upsert(updated.clone()).await;

--- a/examples/web/src/users/controller.rs
+++ b/examples/web/src/users/controller.rs
@@ -35,7 +35,7 @@ impl UsersController {
                 user.username
             );
 
-            return Err(AppError::UserConflictError("username", &user.username))?;
+            Err(AppError::UserConflictError("username", &user.username))?;
         }
 
         self.users.save(&user).await?;
@@ -57,7 +57,7 @@ impl UsersController {
         let body = req.body_validator::<UpdateUserDto>()?;
 
         let Some(existing_user) = self.users.find_by_id(&id).await? else {
-            return Err(AppError::NotFoundError("User not found"))?;
+            Err(AppError::NotFoundError("User not found"))?
         };
 
         let username = body.username.unwrap_or(existing_user.username.clone());
@@ -83,7 +83,7 @@ impl UsersController {
         let id = req.param::<Uuid>("id")?;
 
         let Some(_) = self.users.find_by_id(&id).await? else {
-            return Err(AppError::NotFoundError("User not found"))?;
+            Err(AppError::NotFoundError("User not found"))?
         };
 
         self.users.delete(&id).await?;

--- a/tests/sword-grpc/Cargo.toml
+++ b/tests/sword-grpc/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-sword = { workspace = true, features = ["grpc", "grpc-reflection"] }
+sword = { workspace = true, features = ["grpc", "grpc-reflection", "grpc-error-details"] }
 sword-grpc = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
@@ -16,4 +16,4 @@ serial_test = "3.2.0"
 thiserror = { workspace = true }
 
 [build-dependencies]
-tonic-prost-build = "0.14.2"
+tonic-prost-build = { workspace = true }

--- a/tests/sword-grpc/src/errors.rs
+++ b/tests/sword-grpc/src/errors.rs
@@ -68,6 +68,10 @@ impl proto::user_service_server::UserService for ErrorController {
                 detail: "missing name".into(),
             }
             .into()),
+            "rich" => Err(GrpcStatus::InvalidArgument()
+                .message("bad request")
+                .bad_request("username", "missing")
+                .into()),
             "unavailable" => Err(TestGrpcError::Unavailable.into()),
             _ => Ok(GrpcResponse::message(proto::GetErrorReply {
                 id,
@@ -157,6 +161,39 @@ async fn grpc_error_route_validation_returns_custom_message() {
     let status = result.expect_err("request should fail with invalid_argument");
     assert_eq!(status.code(), Code::InvalidArgument);
     assert_eq!(status.message(), "Field validation failed");
+
+    server.abort();
+}
+
+#[tokio::test]
+#[serial]
+async fn grpc_error_route_rich_details_round_trip() {
+    let server = start_error_server().await;
+    let mut client =
+        proto::user_service_client::UserServiceClient::connect("http://127.0.0.1:50051")
+            .await
+            .expect("client must connect");
+
+    let result = client
+        .get_error(Request::new(proto::GetErrorRequest { id: "rich".into() }))
+        .await;
+
+    let status = result.expect_err("request should fail with invalid_argument");
+    assert_eq!(status.code(), Code::InvalidArgument);
+    assert_eq!(status.message(), "bad request");
+
+    let details = status.get_error_details();
+    let bad_request = details
+        .bad_request()
+        .expect("bad_request details should be present");
+    assert_eq!(bad_request.field_violations.len(), 1);
+    assert_eq!(bad_request.field_violations[0].field, "username");
+    assert_eq!(bad_request.field_violations[0].description, "missing");
+
+    let grpc_status = GrpcStatus::from_status(&status);
+    assert_eq!(grpc_status.code(), Code::InvalidArgument);
+    assert_eq!(grpc_status.message_text(), "bad request");
+    assert!(grpc_status.details().bad_request().is_some());
 
     server.abort();
 }


### PR DESCRIPTION
## Summary

Introduces the gRPC **Richer Error Model** to Sword behind a new opt-in feature, plus dependency bumps.

### `GrpcStatus` builder (`grpc-error-details`)

- New feature `grpc-error-details` on the `sword` facade (and `error-details` on `sword-grpc`), backed by `tonic-types`.
- `GrpcStatus` mirrors the `JsonResponse` builder style: an associated constructor per status code (`GrpcStatus::InvalidArgument()`, `GrpcStatus::NotFound()`, ...) plus chainable error-detail builders (`bad_request`, `localized_message`, `error_info`, `retry_after`, `help`, `debug_info`, `precondition_failure`, `quota_failure`, `request_info`, `resource_info`), converting into `tonic::Status` via `.into()`/`build()`.
- Client-side reconstruction via `GrpcStatus::from_status()`.
- `tonic-types` (with `StatusExt`/`ErrorDetails`) is re-exported behind the feature. Simple errors keep propagating with `?` through the existing `#[derive(GrpcError)]`.

```rust
return Err(
    GrpcStatus::InvalidArgument()
        .message("invalid request")
        .bad_request("username", "username cannot be empty")
        .into(),
);
```

### Example + tests

- gRPC example: `prost-types` Timestamp round-trip (`UserItem.created_at`) and a `GrpcStatus` demo in `create_user`; README documents the pattern.
- `sword-grpc-tests`: rich-error round-trip test (server → client `get_error_details().bad_request()`).

### Dependencies

- Bump tonic crates to 0.14.6 (`tonic`, `tonic-prost`, `tonic-health`, `tonic-reflection`, `tonic-prost-build`).
- Update `validator_derive` to 0.20.1 → replaces `proc-macro-error2` with `proc-macro-error3` (removes a future-incompat warning).
- Fix clippy `needless_return_with_question_mark` in the web example.

Targets the upcoming **v0.3.1** release.