### PR TITLE
fix(docs): replace axum_responses import by sword::web in web docs

### DIFF
--- a/crates/sword-web/src/response/file.rs
+++ b/crates/sword-web/src/response/file.rs
@@ -9,10 +9,11 @@ use axum::{
 /// # Example
 ///
 /// ```rust
-/// use axum_responses::{File, ContentDisposition};
+/// use sword::web::*;
 ///
 /// async fn download() -> File {
 ///     let data = std::fs::read("report.pdf").unwrap();
+///
 ///     File::new()
 ///         .bytes(&data)
 ///         .content_type("application/pdf")

--- a/crates/sword-web/src/response/json.rs
+++ b/crates/sword-web/src/response/json.rs
@@ -18,7 +18,7 @@ use serde_json::{Map, Value};
 /// # Example
 ///
 /// ```rust
-/// use axum_responses::JsonResponse;
+/// use sword::web::*;
 /// use serde_json::json;
 ///
 /// async fn handler() -> JsonResponse {

--- a/crates/sword-web/src/response/redirect.rs
+++ b/crates/sword-web/src/response/redirect.rs
@@ -10,7 +10,7 @@ use axum::{
 /// # Example
 ///
 /// ```rust
-/// use axum_responses::Redirect;
+/// use sword::web::*;
 ///
 /// async fn login_redirect() -> Redirect {
 ///     Redirect::found("/login")


### PR DESCRIPTION
## What Changed
- Replaced the old axum_responses imports with sword::web in sword-web's rustdoc examples.

**Notes**: axum_responses used to be a dependency of sword, but it's now built into the sword-web crate.